### PR TITLE
v0.5.0: createKeySelector baseFn doesn't receive state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-views",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": "github:josepot/redux-views",
   "bugs": "https://github.com/josepot/redux-views/issues",

--- a/src/index.js
+++ b/src/index.js
@@ -130,8 +130,8 @@ export const createKeyedSelectorFactory = (...args) => {
   const [computeFn] = args.splice(-1)
   const dependencies = getDependencies(args)
   const cache = new Map()
-  return selector => {
-    const keySelector = createKeySelector(selector)
+  return fn => {
+    const keySelector = createKeySelector(fn)
     return getInstanceSelector(
       [...dependencies, keySelector],
       computeFn,
@@ -141,9 +141,10 @@ export const createKeyedSelectorFactory = (...args) => {
   }
 }
 
-export const createKeySelector = x => {
-  x.keySelector = x
-  return x
+export const createKeySelector = fn => {
+  const res = (s, ...args) => fn(...args)
+  res.keySelector = res
+  return res
 }
 
 export const createStructuredSelector = obj => {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -51,8 +51,8 @@ describe('createKeyedSelectorFactory', () => {
       (users, key) => users[key]
     )
 
-    const getUserFrom = getUserFactory((s, { from }) => from)
-    const getUserTo = getUserFactory((s, { to }) => to)
+    const getUserFrom = getUserFactory(({ from }) => from)
+    const getUserTo = getUserFactory(({ to }) => to)
 
     expect(getUserFrom(state, { from: 1 })).toBe(state.users[1])
     expect(getUserFrom.recomputations()).toBe(1)
@@ -72,8 +72,8 @@ describe('keyed selectors', () => {
   let getFromProp, getToProp, getUserFrom, getUserTo, joinNames, getJoinedNames
 
   beforeEach(() => {
-    getFromProp = createKeySelector((state, { from }) => from)
-    getToProp = createKeySelector((state, { to }) => to)
+    getFromProp = createKeySelector(({ from }) => from)
+    getToProp = createKeySelector(({ to }) => to)
 
     getUserFrom = createSelector(
       [getFromProp, getUsers],
@@ -240,7 +240,7 @@ describe('keyed selectors', () => {
 
   describe('keySelector', () => {
     test('it should not create new keySelectors unless it is required', () => {
-      const propIdSelector = createKeySelector((state, { id }) => id)
+      const propIdSelector = createKeySelector(({ id }) => id)
 
       const isItemLoadingSelector = createSelector(
         [propIdSelector, () => ({})],
@@ -277,8 +277,8 @@ describe('keyed selectors', () => {
         getUsers,
         (users, key) => users[key]
       )
-      const getUserFrom = getUserFactory((s, { from }) => from)
-      const getUserTo = getUserFactory((s, { to }) => to)
+      const getUserFrom = getUserFactory(({ from }) => from)
+      const getUserTo = getUserFactory(({ to }) => to)
       const compareUsers = createSelector(
         [getUserFrom, getUserTo],
         () => null

--- a/types/createKeySelector.test.ts
+++ b/types/createKeySelector.test.ts
@@ -1,8 +1,8 @@
 import { createKeySelector } from "redux-views";
-import { getSelectedContactId, getContactId } from "./test.types";
+import { PropsA, PropsB } from "./test.types";
 
-// $ExpectType InstanceSelector<{ selectedContact: string; }, string>
-export const selectedContactIdSelector = createKeySelector(getSelectedContactId);
+// $ExpectType ParametricInstanceSelector<{}, PropsA, string>
+export const contactIdSelector = createKeySelector(({ contactId }: PropsA) => contactId);
 
-// $ExpectType ParametricInstanceSelector<unknown, PropsA, string>
-export const contactIdSelector = createKeySelector(getContactId);
+// $ExpectType ParametricInstanceSelector<{}, PropsB, string>
+export const companyIdSelector = createKeySelector<PropsB>(({ companyId }) => companyId);

--- a/types/createKeySelectorFactory.test.ts
+++ b/types/createKeySelectorFactory.test.ts
@@ -8,13 +8,9 @@ const contactSelectorFactory = createKeyedSelectorFactory(
 // $ExpectType true
 type CSF_IS_RIGHT = typeof contactSelectorFactory extends KeyedSelectorFactory<State, Contact> ? true : false;
 
-export const getSelectedContact = contactSelectorFactory(getSelectedContactId);
-// $ExpectType true
-type GSC_IS_RIGHT = typeof getSelectedContact extends InstanceSelector<State, Contact> ? true : false;
-
 export const getContactById = contactSelectorFactory(getContactId);
 // $ExpectType true
 type GCBID_IS_RIGHT = typeof getContactById extends ParametricInstanceSelector<State, PropsA, Contact> ? true : false;
 
 // $ExpectType Contact
-const contact = getSelectedContact(state);
+const contact = getContactById(state, { contactId: '123'});

--- a/types/createSelector.test.ts
+++ b/types/createSelector.test.ts
@@ -1,6 +1,6 @@
-import { createSelector, OutputParametricSelector, OutputParametricInstanceSelector } from "redux-views";
+import { createSelector, OutputParametricSelector } from "redux-views";
 import { getSelectedContactId, getContactId, getContacts, getCompanies, getCompanyId, State, PropsA, PropsB } from "./test.types";
-import { selectedContactIdSelector, contactIdSelector } from "./createKeySelector.test";
+import { contactIdSelector } from "./createKeySelector.test";
 import { getContactById } from "./createKeySelectorFactory.test";
 
 const areEqual = <T>(a: T, b: T) => a === b;
@@ -23,20 +23,6 @@ createSelector(
   areEqual
 );
 
-// $ExpectType OutputSelector<{ selectedContact: string; }, boolean, (res1: string, res2: string) => boolean>
-createSelector(
-  getSelectedContactId,
-  selectedContactIdSelector,
-  areEqual
-);
-
-// $ExpectType OutputSelector<{ selectedContact: string; }, boolean, (res1: string, res2: string) => boolean>
-createSelector(
-  selectedContactIdSelector,
-  getSelectedContactId,
-  areEqual
-);
-
 // $ExpectType OutputParametricSelector<{ selectedContact: string; }, PropsA, boolean, (res1: string, res2: string) => boolean>
 createSelector(
   getSelectedContactId,
@@ -46,13 +32,6 @@ createSelector(
 // $ExpectType OutputParametricSelector<{ selectedContact: string; }, PropsA, boolean, (res1: string, res2: string) => boolean>
 createSelector(
   [getSelectedContactId, contactIdSelector],
-  areEqual
-);
-
-// $ExpectType OutputParametricSelector<{ selectedContact: string; }, PropsA, boolean, (res1: string, res2: string) => boolean>
-createSelector(
-  selectedContactIdSelector,
-  getContactId,
   areEqual
 );
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,22 +38,21 @@ export function isInstanceSelector<S, P, R, C>(selector: OutputParametricSelecto
 /// createKeySelector ///
 /////////////////////////
 
-export interface CreateKeySelector {
-  <S>(keySelector: Selector<S, string>): InstanceSelector<S, string>;
-  <S, P>(keySelector: ParametricSelector<S, P, string>): ParametricInstanceSelector<S, P, string>;
+interface KeySelector<P> {
+  (props: P, ...args: any[]): string;
 }
-export const createKeySelector: CreateKeySelector;
+
+export function createKeySelector<P>(keySelector: KeySelector<P>): ParametricInstanceSelector<{}, P, string>;
 
 //////////////////////////////////
 /// createKeyedSelectorFactory ///
 //////////////////////////////////
 
-export interface KeyedSelectorFactory<S1, T> {
-  <S2>(keySelector: Selector<S2, string>): InstanceSelector<S1 & S2, T>;
-  <S2, P>(keySelector: ParametricSelector<S2, P, string>): ParametricInstanceSelector<S1 & S2, P, T>;
+export interface KeyedSelectorFactory<S, T> {
+  <P>(keySelector: KeySelector<P>): ParametricInstanceSelector<S, P, T>;
 }
-export interface ParametricKeyedSelectorFactory<S1, P1, T> {
-  <S2, P2>(keySelector: ParametricSelector<S2, P2, string>): ParametricInstanceSelector<S1 & S2, P1 & P2, T>;
+export interface ParametricKeyedSelectorFactory<S, P1, T> {
+  <P2>(keySelector: KeySelector<P2>): ParametricInstanceSelector<S, P1 & P2, T>;
 }
 
 export function createKeyedSelectorFactory<S1, R1, T>(


### PR DESCRIPTION
@voliva this is the change that we discussed before.

With this, `createKeySelector` will actually enhance the function that it receives :smile:

I need help with the typings, though. Could you please help with that?