### PR TITLE
v0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-views",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": "github:josepot/redux-views",
   "bugs": "https://github.com/josepot/redux-views/issues",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,11 +12,11 @@ interface InstanceProps<S> {
   keySelector: Selector<S, string>;
 }
 type OutputInstanceProps<S, R, C> = OutputProps<C> & {
-  use: () => [Selector<S, R>, () => void],
+  use: (key: string) => () => void,
   clearCache: (recursive?: boolean) => void,
 };
 type OutputParametricInstanceProps<S, P, R, C> = OutputProps<C> & {
-  use: () => [ParametricSelector<S, P, R>, () => void],
+  use: (key: string) => () => void,
   clearCache: (recursive?: boolean) => void,
 };
 interface ParametricInstanceProps<S, P> {

--- a/types/isInstanceSelector.test.ts
+++ b/types/isInstanceSelector.test.ts
@@ -19,8 +19,8 @@ if (isInstanceSelector(selector)) {
   // $ExpectType OutputInstanceSelector<{ selectedContact: string; }, boolean, (res1: string, res2: string) => boolean>
   selector;
 
-  // $ExpectType [Selector<{ selectedContact: string; }, boolean>, () => void]
-  selector.use();
+  // $ExpectType () => void
+  selector.use('id1');
 }
 
 if (isInstanceSelector(parametricSelector)) {


### PR DESCRIPTION
- Better API for `use`
- Expose `resultFnCached`
- keySelectors must return strings
- Improve `customConnect` example